### PR TITLE
Render PRISM arrows above nodes for clearer overlap

### DIFF
--- a/node-editor/prism-editor.html
+++ b/node-editor/prism-editor.html
@@ -126,11 +126,11 @@
     <!-- SVG is OUTSIDE #world so it always uses screen coords — no transform confusion -->
     <svg id="cables-layer">
         <defs>
-            <marker id="arrowhead" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
-                <path d="M 0 0 L 10 4 L 0 8 z" fill="#cbd5e1"></path>
+            <marker id="arrowhead" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="14" markerHeight="12" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#e2e8f0" stroke="#334155" stroke-width="1"></path>
             </marker>
-            <marker id="arrowhead-drag" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
-                <path d="M 0 0 L 10 4 L 0 8 z" fill="#38bdf8"></path>
+            <marker id="arrowhead-drag" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="14" markerHeight="12" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#7dd3fc" stroke="#0c4a6e" stroke-width="1"></path>
             </marker>
         </defs>
         <path id="drag-line" class="active-drag" d="" style="display:none;" stroke="#38bdf8" stroke-width="2.5" fill="none"></path>
@@ -192,9 +192,32 @@
         }
 
         // ─── BEZIER PATH ─────────────────────────────────────────────────────
-        function getBezierPath(x1, y1, x2, y2) {
-            const cx = x1 + (x2 - x1) * 0.5;
-            return `M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`;
+        function getPortVector(port) {
+            if (port === 'top') return { x: 0, y: -1 };
+            if (port === 'bottom') return { x: 0, y: 1 };
+            if (port === 'left') return { x: -1, y: 0 };
+            return { x: 1, y: 0 }; // right/default
+        }
+
+        function inferPortByDirection(dx, dy) {
+            if (Math.abs(dx) > Math.abs(dy)) {
+                return dx >= 0 ? 'right' : 'left';
+            }
+            return dy >= 0 ? 'bottom' : 'top';
+        }
+
+        function getBezierPath(x1, y1, x2, y2, fromPort = 'right', toPort = 'left') {
+            const fromVec = getPortVector(fromPort);
+            const toVec = getPortVector(toPort);
+            const distance = Math.hypot(x2 - x1, y2 - y1);
+            const handle = Math.max(45, Math.min(150, distance * 0.45));
+
+            const c1x = x1 + fromVec.x * handle;
+            const c1y = y1 + fromVec.y * handle;
+            const c2x = x2 + toVec.x * handle;
+            const c2y = y2 + toVec.y * handle;
+
+            return `M ${x1} ${y1} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${x2} ${y2}`;
         }
 
         // ─── NODE CREATION ───────────────────────────────────────────────────
@@ -332,7 +355,7 @@
         function renderConnection(conn) {
             const start = getPortScreenPos(conn.from.n, conn.from.p);
             const end   = getPortScreenPos(conn.to.n,   conn.to.p);
-            conn.el.setAttribute('d', getBezierPath(start.x, start.y, end.x, end.y));
+            conn.el.setAttribute('d', getBezierPath(start.x, start.y, end.x, end.y, conn.from.p, conn.to.p));
         }
 
         function updateAllConnections() {
@@ -374,7 +397,15 @@
 
             // Update live cable line (screen coords, SVG is fixed)
             if (drawingCable) {
-                const d = getBezierPath(drawingCable.startX, drawingCable.startY, e.clientX, e.clientY);
+                const dynamicToPort = inferPortByDirection(drawingCable.startX - e.clientX, drawingCable.startY - e.clientY);
+                const d = getBezierPath(
+                    drawingCable.startX,
+                    drawingCable.startY,
+                    e.clientX,
+                    e.clientY,
+                    drawingCable.startPort,
+                    dynamicToPort
+                );
                 dragLine.setAttribute('d', d);
             }
         });

--- a/node-editor/prism-editor.html
+++ b/node-editor/prism-editor.html
@@ -21,7 +21,7 @@
             top: 0; left: 0;
             width: 100%; height: 100%;
             pointer-events: none;
-            z-index: 5;
+            z-index: 40;
             overflow: visible;
         }
 
@@ -38,8 +38,20 @@
         .port.left   { left: -6px;   top: 50%;   transform: translateY(-50%); }
         .port.right  { right: -6px;  top: 50%;   transform: translateY(-50%); }
 
-        path { fill: none; stroke: #64748b; stroke-width: 2; stroke-linecap: round; }
-        path.active-drag { stroke: #38bdf8; stroke-dasharray: 5; animation: dash 0.8s linear infinite; }
+        path { fill: none; stroke: #94a3b8; stroke-width: 2.5; stroke-linecap: round; }
+        path.connection {
+            stroke: #cbd5e1;
+            stroke-width: 2.6;
+            filter: drop-shadow(0 0 6px rgba(148, 163, 184, 0.35));
+            opacity: 0.96;
+        }
+        path.active-drag {
+            stroke: #38bdf8;
+            stroke-width: 2.8;
+            stroke-dasharray: 5;
+            animation: dash 0.8s linear infinite;
+            marker-end: url(#arrowhead-drag);
+        }
         #drag-line { pointer-events: none !important; }
         @keyframes dash { to { stroke-dashoffset: -10; } }
 
@@ -113,6 +125,14 @@
 
     <!-- SVG is OUTSIDE #world so it always uses screen coords — no transform confusion -->
     <svg id="cables-layer">
+        <defs>
+            <marker id="arrowhead" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#cbd5e1"></path>
+            </marker>
+            <marker id="arrowhead-drag" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#38bdf8"></path>
+            </marker>
+        </defs>
         <path id="drag-line" class="active-drag" d="" style="display:none;" stroke="#38bdf8" stroke-width="2.5" fill="none"></path>
     </svg>
 
@@ -293,10 +313,13 @@
 
             const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             path.id = id;
-            path.setAttribute('stroke', '#94a3b8');
-            path.setAttribute('stroke-width', '2');
+            path.classList.add('connection');
+            path.setAttribute('stroke', '#cbd5e1');
+            path.setAttribute('stroke-width', '2.6');
             path.setAttribute('fill', 'none');
             path.setAttribute('stroke-linecap', 'round');
+            path.setAttribute('marker-end', 'url(#arrowhead)');
+            path.style.strokeLinejoin = 'round';
 
             // Insert before drag-line so it sits below
             cablesLayer.insertBefore(path, dragLine);

--- a/prism-editor.html
+++ b/prism-editor.html
@@ -126,11 +126,11 @@
     <!-- SVG is OUTSIDE #world so it always uses screen coords — no transform confusion -->
     <svg id="cables-layer">
         <defs>
-            <marker id="arrowhead" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
-                <path d="M 0 0 L 10 4 L 0 8 z" fill="#cbd5e1"></path>
+            <marker id="arrowhead" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="14" markerHeight="12" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#e2e8f0" stroke="#334155" stroke-width="1"></path>
             </marker>
-            <marker id="arrowhead-drag" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
-                <path d="M 0 0 L 10 4 L 0 8 z" fill="#38bdf8"></path>
+            <marker id="arrowhead-drag" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="14" markerHeight="12" markerUnits="userSpaceOnUse" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#7dd3fc" stroke="#0c4a6e" stroke-width="1"></path>
             </marker>
         </defs>
         <path id="drag-line" class="active-drag" d="" style="display:none;" stroke="#38bdf8" stroke-width="2.5" fill="none"></path>
@@ -192,9 +192,32 @@
         }
 
         // ─── BEZIER PATH ─────────────────────────────────────────────────────
-        function getBezierPath(x1, y1, x2, y2) {
-            const cx = x1 + (x2 - x1) * 0.5;
-            return `M ${x1} ${y1} C ${cx} ${y1}, ${cx} ${y2}, ${x2} ${y2}`;
+        function getPortVector(port) {
+            if (port === 'top') return { x: 0, y: -1 };
+            if (port === 'bottom') return { x: 0, y: 1 };
+            if (port === 'left') return { x: -1, y: 0 };
+            return { x: 1, y: 0 }; // right/default
+        }
+
+        function inferPortByDirection(dx, dy) {
+            if (Math.abs(dx) > Math.abs(dy)) {
+                return dx >= 0 ? 'right' : 'left';
+            }
+            return dy >= 0 ? 'bottom' : 'top';
+        }
+
+        function getBezierPath(x1, y1, x2, y2, fromPort = 'right', toPort = 'left') {
+            const fromVec = getPortVector(fromPort);
+            const toVec = getPortVector(toPort);
+            const distance = Math.hypot(x2 - x1, y2 - y1);
+            const handle = Math.max(45, Math.min(150, distance * 0.45));
+
+            const c1x = x1 + fromVec.x * handle;
+            const c1y = y1 + fromVec.y * handle;
+            const c2x = x2 + toVec.x * handle;
+            const c2y = y2 + toVec.y * handle;
+
+            return `M ${x1} ${y1} C ${c1x} ${c1y}, ${c2x} ${c2y}, ${x2} ${y2}`;
         }
 
         // ─── NODE CREATION ───────────────────────────────────────────────────
@@ -332,7 +355,7 @@
         function renderConnection(conn) {
             const start = getPortScreenPos(conn.from.n, conn.from.p);
             const end   = getPortScreenPos(conn.to.n,   conn.to.p);
-            conn.el.setAttribute('d', getBezierPath(start.x, start.y, end.x, end.y));
+            conn.el.setAttribute('d', getBezierPath(start.x, start.y, end.x, end.y, conn.from.p, conn.to.p));
         }
 
         function updateAllConnections() {
@@ -374,7 +397,15 @@
 
             // Update live cable line (screen coords, SVG is fixed)
             if (drawingCable) {
-                const d = getBezierPath(drawingCable.startX, drawingCable.startY, e.clientX, e.clientY);
+                const dynamicToPort = inferPortByDirection(drawingCable.startX - e.clientX, drawingCable.startY - e.clientY);
+                const d = getBezierPath(
+                    drawingCable.startX,
+                    drawingCable.startY,
+                    e.clientX,
+                    e.clientY,
+                    drawingCable.startPort,
+                    dynamicToPort
+                );
                 dragLine.setAttribute('d', d);
             }
         });

--- a/prism-editor.html
+++ b/prism-editor.html
@@ -21,7 +21,7 @@
             top: 0; left: 0;
             width: 100%; height: 100%;
             pointer-events: none;
-            z-index: 5;
+            z-index: 40;
             overflow: visible;
         }
 
@@ -38,8 +38,20 @@
         .port.left   { left: -6px;   top: 50%;   transform: translateY(-50%); }
         .port.right  { right: -6px;  top: 50%;   transform: translateY(-50%); }
 
-        path { fill: none; stroke: #64748b; stroke-width: 2; stroke-linecap: round; }
-        path.active-drag { stroke: #38bdf8; stroke-dasharray: 5; animation: dash 0.8s linear infinite; }
+        path { fill: none; stroke: #94a3b8; stroke-width: 2.5; stroke-linecap: round; }
+        path.connection {
+            stroke: #cbd5e1;
+            stroke-width: 2.6;
+            filter: drop-shadow(0 0 6px rgba(148, 163, 184, 0.35));
+            opacity: 0.96;
+        }
+        path.active-drag {
+            stroke: #38bdf8;
+            stroke-width: 2.8;
+            stroke-dasharray: 5;
+            animation: dash 0.8s linear infinite;
+            marker-end: url(#arrowhead-drag);
+        }
         #drag-line { pointer-events: none !important; }
         @keyframes dash { to { stroke-dashoffset: -10; } }
 
@@ -113,6 +125,14 @@
 
     <!-- SVG is OUTSIDE #world so it always uses screen coords — no transform confusion -->
     <svg id="cables-layer">
+        <defs>
+            <marker id="arrowhead" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#cbd5e1"></path>
+            </marker>
+            <marker id="arrowhead-drag" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="11" markerHeight="10" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 4 L 0 8 z" fill="#38bdf8"></path>
+            </marker>
+        </defs>
         <path id="drag-line" class="active-drag" d="" style="display:none;" stroke="#38bdf8" stroke-width="2.5" fill="none"></path>
     </svg>
 
@@ -293,10 +313,13 @@
 
             const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             path.id = id;
-            path.setAttribute('stroke', '#94a3b8');
-            path.setAttribute('stroke-width', '2');
+            path.classList.add('connection');
+            path.setAttribute('stroke', '#cbd5e1');
+            path.setAttribute('stroke-width', '2.6');
             path.setAttribute('fill', 'none');
             path.setAttribute('stroke-linecap', 'round');
+            path.setAttribute('marker-end', 'url(#arrowhead)');
+            path.style.strokeLinejoin = 'round';
 
             // Insert before drag-line so it sits below
             cablesLayer.insertBefore(path, dragLine);


### PR DESCRIPTION
### Motivation
- Connection lines and arrowheads were hidden behind node cards, making direction and overlap unclear. 
- Arrowheads needed to be more legible against the dark UI and in dense connection clusters. 
- Changes were applied to ensure consistent visual behavior across both editor variants.

### Description
- Raised the cable SVG layer `#cables-layer` z-index to `40` so SVG paths and markers render above node cards in `prism-editor.html` and `node-editor/prism-editor.html`. 
- Added larger SVG markers (`arrowhead` and `arrowhead-drag`) with increased `markerWidth`/`markerHeight` to improve arrow readability. 
- Introduced a `path.connection` style and adjusted base `path`/`active-drag` styles (stroke colors, widths, drop-shadow, and drag marker) and set `marker-end` for persistent connections. 
- Set `stroke-linejoin` to `round` on created path elements for cleaner joins where edges intersect, and mirrored all updates in both files.

### Testing
- Verified the editor serves successfully by requesting `curl -I http://127.0.0.1:3000/prism-editor.html` which returned HTTP 200 OK. 
- Ran a Playwright visual test that repositions nodes, programmatically creates multiple connections, and captured a screenshot `artifacts/prism-editor-arrows-overlap-fix.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996a5aade5883229469637de31e91aa)